### PR TITLE
Update app.js and mediaUpload.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,13 +10,10 @@ const NodeCache = require("node-cache");
 dotenv.config({ path: "./config/config.env" });
 
 exports.myCache = new NodeCache();
-app.use(express.json());
 app.use(cookieParser());
-app.use(
-  express.urlencoded({
-    extended: true,
-  })
-);
+app.use(express.json({ limit: '500mb' }));
+app.use(express.urlencoded({ limit: '500mb', extended: true }));
+
 
 app.use(
   cors({

--- a/middleware/mediaUpload.js
+++ b/middleware/mediaUpload.js
@@ -25,7 +25,7 @@ const validateMediaType = (allowedTypes) => (req, file, cb) => {
 const uploadConfig = multer({
     storage: storage,
     limits: {
-        fileSize: 100 * 1024 * 1024, // 100MB max file size
+        fileSize: 500 * 1024 * 1024,
     }
 });
 


### PR DESCRIPTION
- Set limit for JSON and URL encoded data in app.js to 500mb
- Increase maximum file size limit to 500MB in mediaUpload.js